### PR TITLE
メッセージ送信機能の非同期化

### DIFF
--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,0 +1,50 @@
+$(document).on('turbolinks:load', function(){
+  function buildHTML(message){
+    var img = message.image ? `<img src= ${ message.image }>` : "";
+    var content = message.content ? `${ message.content }` : "";
+    var html = `  <div class="all__chat__main__class">
+                    <div class="all__chat__main__class__name">
+                      <p class="all__chat__main__class__name__group">
+                        ${message.user_name}
+                        </p>
+                      <p class="all__chat__main__class__name__info">
+                        ${message.date}
+                        </p>
+                        </div>
+                    <div class="all__chat__main__class__message">
+                      <div class=lower-message_content>
+                      ${content}
+                      </div>
+                      ${img}
+                      </p>
+                      </div>`
+      return html;
+  }
+
+  $('#new_message').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action')
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+  })
+  .done(function(data){
+    var html = buildHTML(data);
+    $('.all__chat__main').append(html)
+    $('#message_content').val('')
+    $("#new_message")[0].reset();
+    $('.all__chat__main').animate({ scrollTop: $('.all__chat__main')[0].scrollHeight });
+  })
+  .fail(function(){
+    alert('error');
+  })
+  .always(function(data){
+    $('.all__chat__footer__class__send').prop('disabled', false);
+  })
+})
+})

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,10 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.html { redirect_to group_messages_path(@group)  }
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,6 @@
+json.content  @message.content
+json.user_id  @message.user.id
+json.user_name @message.user.name
+json.group_id  @message.group.id
+json.image  @message.image.url
+json.date  @message.created_at.strftime("%Y/%m/%d %H:%M")

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -29,5 +29,7 @@
               = f.label :image, class: 'all__chat__footer__class__input__box' do
                 = fa_icon 'picture-o', class: 'all__chat__btn'
                 = f.file_field :image, class: 'all__chat__file'
-          .all__chat__footer__class__send    
-            = f.submit 'Send', class: 'all__chat__footer__class__send'
+          .all__chat__footer__class__send
+            = f.submit 'Send', class: 'all__chat__footer__class__send', id: 'new_message'
+
+            

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  ##config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/db/migrate/20190923052510_create_messages.rb
+++ b/db/migrate/20190923052510_create_messages.rb
@@ -2,7 +2,7 @@ class CreateMessages < ActiveRecord::Migration[5.0]
   def change
     create_table :messages do |t|
       t.string :content
-      t.string :image
+      t.text :image
       t.references :group, foreign_key: true
       t.references :user, foreign_key: true
       t.timestamps


### PR DESCRIPTION
#What
メッセージ送信機能の非同期化。respond_toを使用してHTMLとJSONの場合で処理を分けし、jbuilderを使用して、作成したメッセージをJSON形式で返す。

#Why
操作性を高めるため。